### PR TITLE
 add service worker for cache cleanup and page reload

### DIFF
--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -49,6 +49,15 @@
         gtag('config', 'G-LMCFJ7SKM4');
     </script>
     <script data-name="BMC-Widget" data-cfasync="false" src="https://cdnjs.buymeacoffee.com/1.0.0/widget.prod.min.js" data-id="goforgoldman" data-description="Support me on Buy me a coffee!" data-message="Hope you're enjoying my content! 😊" data-color="#FF813F" data-position="Right" data-x_margin="18" data-y_margin="18"></script>
+
+    <script>
+        // TEMP: register cleanup SW to evict old Jekyll SW and caches
+        if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('/sw.js', { scope: '/' })
+            .catch(() => {/* ignore */});
+        }
+    </script>
+
 </body>
 
 </html>

--- a/wwwroot/sw.js
+++ b/wwwroot/sw.js
@@ -1,0 +1,18 @@
+// sw.js — one-time cleanup worker
+self.addEventListener('install', () => self.skipWaiting());
+
+self.addEventListener('activate', async () => {
+  try {
+    // Delete ALL caches
+    const keys = await caches.keys();
+    await Promise.all(keys.map(k => caches.delete(k)));
+    // Unregister this SW
+    await self.registration.unregister();
+  } finally {
+    // Take control of open pages
+    await self.clients.claim();
+    // Tell pages to reload (best effort)
+    const all = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+    for (const client of all) client.navigate(client.url);
+  }
+});


### PR DESCRIPTION
This pull request is intended to unregister a service worker that was installed by a previous version of this site (running Jekyll) that is preventing browsers from receiving new content.

The site has been updated to run on Blazor and does not currently have a service worker. When a user visits the site, the installed service worker checks for a specific cache name version and fetches new content. Otherwise content is served from the cache. As the new site does not include all the exact same scripts and cache name logic, users are not able to see new content.

This change provides a temporary change to intercept that, add logic for the service worker to nuke the cache, and unregister itself. After time passes, this can be removed.