### PR TITLE
Add Maui UI content entry

### DIFF
--- a/data/mauiuijuly-2026.csv
+++ b/data/mauiuijuly-2026.csv
@@ -8,7 +8,7 @@ DayOfMonth,Person,ContentName,ContentUrl,SecondaryUrl,SecondaryLabel
 7,Available,,,,
 8,Available,,,,
 9,David Ortinau,Build the tools you need,https://dev.to/davidortinau/build-the-tools-you-need-4ji0,,
-10,Thomas Sebastian Jensen,TBC,,,
+10,Thomas Sebastian Jensen,Building a Seven-Segment Display Control,https://medium.com/@tsjdevapps/building-a-seven-segment-display-control-with-net-maui-and-skiasharp-739adf1ca8d9,,
 11,Available,,,,
 12,Available,,,,
 13,Available,,,,


### PR DESCRIPTION
This pull request updates the content for July 10th in the `data/mauiuijuly-2026.csv` file. The most important change is updating the session topic and adding a relevant link for Thomas Sebastian Jensen.

Content updates:

* Updated the entry for July 10th to specify Thomas Sebastian Jensen's session as "Building a Seven-Segment Display Control" and added a Medium article link as the content URL.